### PR TITLE
Add service and API tests for Django backend

### DIFF
--- a/backend/scrna_ai_insights/api.py
+++ b/backend/scrna_ai_insights/api.py
@@ -16,7 +16,8 @@ api = NinjaAPI(title="SingleCell AI Insights", version="0.1.0")
 def get_reports(request):
     """Return the catalog of curated nf-core/singlecell reports."""
 
-    return list_reports()
+    return [report.model_dump(mode="json") for report in list_reports()]
+
 
 
 @api.get("/reports/{report_id}/artifacts", response=List[ArtifactReference])
@@ -24,7 +25,7 @@ def get_report_artifacts(request, report_id: str):
     """Return artifact references tied to a single report."""
 
     try:
-        return list_artifacts(report_id)
+        return [artifact.model_dump(mode="json") for artifact in list_artifacts(report_id)]
     except ReportNotFoundError as exc:  # pragma: no cover - defensive branch
         raise HttpError(404, str(exc)) from exc
 
@@ -34,6 +35,6 @@ def post_chat_query(request, payload: ChatQueryRequest):
     """Return a placeholder chat response for the requested report."""
 
     try:
-        return answer_chat_query(payload)
+        return answer_chat_query(payload).model_dump(mode="json")
     except ReportNotFoundError as exc:
         raise HttpError(404, str(exc)) from exc

--- a/backend/scrna_ai_insights/schemas.py
+++ b/backend/scrna_ai_insights/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Literal, Optional
 
 from ninja import Schema
-from pydantic import AnyHttpUrl, Field
+from pydantic import AnyHttpUrl, Field, field_serializer
 
 
 class ReportSummary(Schema):
@@ -22,6 +22,10 @@ class ArtifactReference(Schema):
     type: str
     label: str
     url: AnyHttpUrl
+
+    @field_serializer('url')
+    def _serialize_url(self, value, _info):
+        return str(value)
 
 
 class ChatMessage(Schema):

--- a/backend/scrna_ai_insights/tests/test_api.py
+++ b/backend/scrna_ai_insights/tests/test_api.py
@@ -1,0 +1,74 @@
+"""Integration tests for the public Django Ninja API."""
+from __future__ import annotations
+
+import json
+
+from django.test import SimpleTestCase
+
+
+class ApiEndpointTests(SimpleTestCase):
+    """Exercise the HTTP endpoints exposed by the backend."""
+
+    def test_get_reports_returns_catalog(self) -> None:
+        response = self.client.get("/api/reports")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIsInstance(payload, list)
+        self.assertGreaterEqual(len(payload), 2)
+        first_report = payload[0]
+        self.assertEqual(first_report["id"], "report-001")
+        self.assertIn("title", first_report)
+        self.assertIn("available_artifacts", first_report)
+
+    def test_get_report_artifacts_success(self) -> None:
+        response = self.client.get("/api/reports/report-001/artifacts")
+
+        self.assertEqual(response.status_code, 200)
+        artifacts = response.json()
+        self.assertIsInstance(artifacts, list)
+        self.assertGreaterEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0]["type"], "html")
+        self.assertIn("url", artifacts[0])
+
+    def test_get_report_artifacts_missing_report(self) -> None:
+        response = self.client.get("/api/reports/unknown-report/artifacts")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Report 'unknown-report' was not found."})
+
+    def test_post_chat_query_returns_answer(self) -> None:
+        payload = {
+            "report_id": "report-001",
+            "user_query": "Summarize the findings",
+            "conversation_context": [],
+        }
+
+        response = self.client.post(
+            "/api/chat/query",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("placeholder answer", data["answer"])
+        self.assertIn("citations", data)
+        self.assertEqual(len(data["citations"]), 1)
+        self.assertIn("follow_up_questions", data)
+        self.assertEqual(len(data["follow_up_questions"]), 2)
+
+    def test_post_chat_query_missing_report(self) -> None:
+        payload = {
+            "report_id": "unknown-report",
+            "user_query": "Summarize the findings",
+        }
+
+        response = self.client.post(
+            "/api/chat/query",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Report 'unknown-report' was not found."})

--- a/backend/scrna_ai_insights/tests/test_services.py
+++ b/backend/scrna_ai_insights/tests/test_services.py
@@ -1,0 +1,53 @@
+"""Unit tests for the service-layer utilities."""
+from __future__ import annotations
+
+from django.test import SimpleTestCase
+
+from scrna_ai_insights import services
+from scrna_ai_insights.schemas import ChatQueryRequest
+
+
+class ServiceUtilitiesTests(SimpleTestCase):
+    """Validate the behavior of service helper functions."""
+
+    def test_list_reports_returns_all_reports(self) -> None:
+        reports = services.list_reports()
+
+        self.assertGreaterEqual(len(reports), 2)
+        self.assertEqual(reports[0].id, "report-001")
+        self.assertEqual(reports[0].title, "Patient A – Baseline")
+        self.assertIn("html", reports[0].available_artifacts)
+
+    def test_list_artifacts_requires_known_report(self) -> None:
+        artifacts = services.list_artifacts("report-001")
+
+        self.assertGreaterEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, "html")
+
+        with self.assertRaises(services.ReportNotFoundError):
+            services.list_artifacts("unknown-report")
+
+    def test_answer_chat_query_includes_placeholder_details(self) -> None:
+        payload = ChatQueryRequest(
+            report_id="report-001",
+            user_query="Summarize the findings",
+            conversation_context=[],
+        )
+
+        response = services.answer_chat_query(payload)
+
+        self.assertIn("placeholder answer", response.answer)
+        self.assertEqual(len(response.citations), 1)
+        self.assertEqual(response.citations[0].type, "html")
+        self.assertEqual(response.follow_up_questions, [
+            "Would you like a breakdown of the QC filtering thresholds?",
+            "Should I summarize differential expression highlights?",
+        ])
+
+        with self.assertRaises(services.ReportNotFoundError):
+            services.answer_chat_query(
+                ChatQueryRequest(
+                    report_id="unknown-report",
+                    user_query="hello",
+                )
+            )


### PR DESCRIPTION
## Summary
- add unit tests covering report listing, artifact retrieval, and chat response helpers
- add integration tests for the Django Ninja API endpoints for success and not-found cases
- ensure API responses serialize URL fields by dumping schemas in JSON mode and serializing AnyHttpUrl values

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d04a1b5b308321a16cdfdb5dbfa38a