### PR TITLE
Add React frontend for SingleCell AI Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This repository contains a proof-of-concept platform that explores how a conversational
 assistant can help researchers interrogate curated nf-core/singlecell reports.
 
+The codebase is split into two major pieces:
+
+- A minimal Django + Django Ninja backend that exposes the API contract outlined in
+  [`SPEC.md`](./SPEC.md).
+- A Vite-powered React frontend that consumes the backend and offers report browsing,
+  artifact exploration, and a conversational assistant experience.
+
+The sections below walk through the expected local development workflow for both halves
+of the stack.
+
 ## Backend (Django + Django Ninja)
 
 A lightweight Django project powers the API surface that the frontend will consume,
@@ -42,3 +52,48 @@ The API will be available at `http://127.0.0.1:8000/api/`. Example endpoints inc
 These endpoints currently return static placeholder data to illustrate the wire format
 for future integrations with the retrieval layer, vector store, and AWS Bedrock model
 invocations outlined in the specification.
+
+## Frontend (React + Vite + TypeScript)
+
+The frontend lives in the `frontend/` directory and is scaffolded with Vite and React
+Query. It is responsible for rendering the report selector, chat panel, and contextual
+artifact browser that orchestrate requests against the Django API described above.
+
+### Getting started
+
+1. Install the JavaScript dependencies (Node.js 18+ recommended):
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. Start the Vite development server:
+
+   ```bash
+   npm run dev -- --host
+   ```
+
+   The `--host` flag allows external connections (e.g., Docker port forwarding). By
+   default, the app will be served at `http://127.0.0.1:5173`.
+
+3. Ensure the Django API is running (see the backend instructions above). The frontend
+   expects the API to be reachable at `http://127.0.0.1:8000/api`. If you need to target
+   a different origin, update the `API_BASE_URL` constant in `frontend/src/api.ts`.
+
+During development Vite automatically hot-reloads the UI whenever files under
+`frontend/src/` change.
+
+## Running the full stack
+
+To exercise the full experience locally:
+
+1. Start the Django API server on port `8000`.
+2. Launch the Vite dev server on port `5173`.
+3. Navigate to the frontend in your browser. Selecting a report will populate the chat
+   and context panes using the mock payloads provided by the backend.
+
+Because the backend currently returns static data, the chat interface will always
+respond with the same placeholder conversation. This scaffolding is intentionally
+lightweight so that the retrieval and LLM integration layers described in the spec can
+be swapped in with minimal plumbing changes.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SingleCell AI Insights</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,98 @@
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+}
+
+.app-header {
+  padding: 1.25rem 2rem;
+  background-color: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.28);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.app-body {
+  display: grid;
+  grid-template-columns: 280px 1fr 320px;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+.panel {
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem;
+  box-shadow: 0 15px 50px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.panel-header {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.panel-content {
+  padding: 1.25rem 1.5rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chat-panel .panel-content {
+  padding: 0;
+}
+
+@media (max-width: 1200px) {
+  .app-body {
+    grid-template-columns: 240px 1fr;
+  }
+
+  .context-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-body {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .report-panel {
+    order: 1;
+  }
+
+  .chat-panel {
+    order: 2;
+  }
+
+  .app-header {
+    padding: 1rem 1.25rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from "react";
+import "./App.css";
+import { ChatPanel } from "./components/ChatPanel";
+import { ContextPanel } from "./components/ContextPanel";
+import { ReportSelector } from "./components/ReportSelector";
+import { useReports } from "./hooks/useReports";
+import type { ChatConversationItem, ReportSummary } from "./types";
+
+function resolveSelectedReport(
+  reports: ReportSummary[],
+  preferredId: string | null
+): ReportSummary | null {
+  if (!preferredId) {
+    return null;
+  }
+
+  return reports.find((report) => report.id === preferredId) ?? null;
+}
+
+export default function App() {
+  const { data: reports = [], isLoading, isError } = useReports();
+  const [selectedReportId, setSelectedReportId] = useState<string | null>(null);
+  const [conversation, setConversation] = useState<ChatConversationItem[]>([]);
+
+  useEffect(() => {
+    if (!isLoading && !isError && reports.length > 0 && !selectedReportId) {
+      setSelectedReportId(reports[0].id);
+    }
+  }, [isLoading, isError, reports, selectedReportId]);
+
+  const selectedReport = useMemo(
+    () => resolveSelectedReport(reports, selectedReportId),
+    [reports, selectedReportId]
+  );
+
+  const handleReportSelection = (reportId: string) => {
+    setSelectedReportId(reportId);
+    setConversation([]);
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>SingleCell AI Insights</h1>
+          <p className="tagline">Chat with curated nf-core/singlecell reports.</p>
+        </div>
+      </header>
+      <main className="app-body">
+        <section className="panel report-panel">
+          <div className="panel-header">
+            <h2>Reports</h2>
+          </div>
+          <div className="panel-content">
+            <ReportSelector
+              reports={reports}
+              isLoading={isLoading}
+              isError={isError}
+              selectedReportId={selectedReportId}
+              onSelect={handleReportSelection}
+            />
+          </div>
+        </section>
+        <section className="panel chat-panel">
+          <div className="panel-header">
+            <h2>Assistant</h2>
+          </div>
+          <div className="panel-content">
+            <ChatPanel
+              report={selectedReport}
+              conversation={conversation}
+              onConversationUpdate={setConversation}
+            />
+          </div>
+        </section>
+        <section className="panel context-panel">
+          <div className="panel-header">
+            <h2>Context</h2>
+          </div>
+          <div className="panel-content">
+            <ContextPanel report={selectedReport} />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,53 @@
+import type {
+  ArtifactReference,
+  ChatMessage,
+  ChatQueryResponse,
+  ReportSummary
+} from "./types";
+
+const DEFAULT_BASE_URL = "/api";
+const baseUrl = (import.meta.env.VITE_API_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  if (!path.startsWith("/")) {
+    throw new Error("API request paths must start with '/' ");
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {})
+    },
+    ...init
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function fetchReports(): Promise<ReportSummary[]> {
+  return request<ReportSummary[]>("/reports");
+}
+
+export function fetchArtifacts(reportId: string): Promise<ArtifactReference[]> {
+  return request<ArtifactReference[]>(`/reports/${reportId}/artifacts`);
+}
+
+export function submitChatQuery(
+  reportId: string,
+  userQuery: string,
+  context: ChatMessage[]
+): Promise<ChatQueryResponse> {
+  return request<ChatQueryResponse>("/chat/query", {
+    method: "POST",
+    body: JSON.stringify({
+      report_id: reportId,
+      user_query: userQuery,
+      conversation_context: context
+    })
+  });
+}

--- a/frontend/src/components/ChatPanel.css
+++ b/frontend/src/components/ChatPanel.css
@@ -1,0 +1,159 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat-history {
+  flex: 1;
+  padding: 1.25rem 1.5rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.chat-message {
+  border-radius: 0.9rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.chat-message header {
+  font-weight: 600;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.chat-message p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.chat-message.user {
+  justify-self: end;
+  background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
+  color: #eef2ff;
+}
+
+.chat-message.assistant {
+  justify-self: start;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(79, 70, 229, 0.12);
+}
+
+.citation-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.85rem;
+  color: inherit;
+}
+
+.citation-list a {
+  color: inherit;
+}
+
+.follow-up-group {
+  background: rgba(99, 102, 241, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.follow-up-buttons {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.follow-up-buttons button {
+  border: none;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.9);
+  color: #312e81;
+  box-shadow: 0 6px 18px rgba(99, 102, 241, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.follow-up-buttons button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.3);
+}
+
+.follow-up-buttons button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chat-input {
+  padding: 1.1rem 1.5rem 1.4rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.85);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.chat-input textarea {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 0.9rem 1rem;
+  resize: vertical;
+  min-height: 120px;
+  font-size: 0.95rem;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.chat-input textarea:focus {
+  outline: none;
+  border-color: rgba(79, 70, 229, 0.6);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.chat-input-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.chat-input-actions button {
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 32px rgba(79, 70, 229, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.chat-input-actions button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.chat-input-actions button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(79, 70, 229, 0.45);
+}
+
+.empty-state {
+  text-align: center;
+  color: #475569;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.empty-state strong {
+  color: #312e81;
+}
+
+.hint {
+  font-size: 0.9rem;
+  color: #64748b;
+}

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,0 +1,154 @@
+import { type Dispatch, type SetStateAction, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { submitChatQuery } from "../api";
+import type { ChatConversationItem, ChatMessage, ReportSummary } from "../types";
+import "./ChatPanel.css";
+
+interface ChatPanelProps {
+  report: ReportSummary | null;
+  conversation: ChatConversationItem[];
+  onConversationUpdate: Dispatch<SetStateAction<ChatConversationItem[]>>;
+}
+
+const createMessageId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+type MutationPayload = {
+  reportId: string;
+  userQuery: string;
+  context: ChatMessage[];
+};
+
+export function ChatPanel({ report, conversation, onConversationUpdate }: ChatPanelProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: ({ reportId, userQuery, context }: MutationPayload) =>
+      submitChatQuery(reportId, userQuery, context)
+  });
+
+  const sendPrompt = (rawValue: string) => {
+    if (!report) {
+      return;
+    }
+
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const context: ChatMessage[] = conversation.map(({ role, content }) => ({ role, content }));
+    const userMessage: ChatConversationItem = {
+      id: createMessageId(),
+      role: "user",
+      content: trimmed
+    };
+
+    onConversationUpdate((prev) => [...prev, userMessage]);
+    setInputValue("");
+
+    mutation.mutate(
+      { reportId: report.id, userQuery: trimmed, context },
+      {
+        onSuccess: (data) => {
+          const assistantMessage: ChatConversationItem = {
+            id: createMessageId(),
+            role: "assistant",
+            content: data.answer,
+            citations: data.citations,
+            follow_up_questions: data.follow_up_questions
+          };
+          onConversationUpdate((prev) => [...prev, assistantMessage]);
+        },
+        onError: (error) => {
+          const assistantMessage: ChatConversationItem = {
+            id: createMessageId(),
+            role: "assistant",
+            content: `Sorry, something went wrong: ${(error as Error).message}`
+          };
+          onConversationUpdate((prev) => [...prev, assistantMessage]);
+        }
+      }
+    );
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    sendPrompt(inputValue);
+  };
+
+  const handleFollowUp = (question: string) => {
+    sendPrompt(question);
+  };
+
+  if (!report) {
+    return (
+      <div className="empty-state">
+        <p>Select a report to begin exploring insights.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chat-container">
+      <div className="chat-history">
+        {conversation.length === 0 ? (
+          <div className="empty-state">
+            <p>
+              Ask a question about <strong>{report.title}</strong> to start the conversation.
+            </p>
+            <p className="hint">Example: “Which clusters show the highest mitochondrial gene expression?”</p>
+          </div>
+        ) : (
+          conversation.map((message) => (
+            <article key={message.id} className={`chat-message ${message.role}`}>
+              <header>{message.role === "user" ? "You" : "AI Assistant"}</header>
+              <p>{message.content}</p>
+              {message.citations && message.citations.length > 0 && (
+                <ul className="citation-list">
+                  {message.citations.map((citation) => (
+                    <li key={`${message.id}-${citation.url}`}>
+                      <a href={citation.url} target="_blank" rel="noreferrer">
+                        {citation.label} ({citation.type})
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {message.follow_up_questions && message.follow_up_questions.length > 0 && (
+                <div className="follow-up-group">
+                  <span>Suggested follow-ups:</span>
+                  <div className="follow-up-buttons">
+                    {message.follow_up_questions.map((question) => (
+                      <button
+                        key={`${message.id}-${question}`}
+                        type="button"
+                        onClick={() => handleFollowUp(question)}
+                        disabled={mutation.isPending}
+                      >
+                        {question}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </article>
+          ))
+        )}
+      </div>
+      <form className="chat-input" onSubmit={handleSubmit}>
+        <textarea
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          placeholder="Ask about QC metrics, cluster patterns, or differential expression…"
+          rows={3}
+          disabled={mutation.isPending}
+        />
+        <div className="chat-input-actions">
+          <button type="submit" disabled={mutation.isPending || !inputValue.trim()}>
+            {mutation.isPending ? "Thinking…" : "Send"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/ContextPanel.css
+++ b/frontend/src/components/ContextPanel.css
@@ -1,0 +1,68 @@
+.context-container {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  height: 100%;
+}
+
+.context-report h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.context-report p {
+  margin: 0.5rem 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.context-artifacts h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #4338ca;
+}
+
+.context-artifacts ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.context-artifacts li {
+  display: grid;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+}
+
+.context-artifacts a {
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.context-artifacts a:hover {
+  text-decoration: underline;
+}
+
+.artifact-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6366f1;
+}
+
+.context-empty {
+  height: 100%;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  color: #475569;
+  padding: 0 1.5rem;
+}

--- a/frontend/src/components/ContextPanel.tsx
+++ b/frontend/src/components/ContextPanel.tsx
@@ -1,0 +1,52 @@
+import { useArtifacts } from "../hooks/useArtifacts";
+import type { ReportSummary } from "../types";
+import "./ContextPanel.css";
+
+interface ContextPanelProps {
+  report: ReportSummary | null;
+}
+
+export function ContextPanel({ report }: ContextPanelProps) {
+  const { data: artifacts = [], isLoading, isError } = useArtifacts(report ? report.id : null);
+
+  if (!report) {
+    return (
+      <div className="context-empty">
+        <p>Select a report to view its related artifacts.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="context-container">
+      <section className="context-report">
+        <h3>{report.title}</h3>
+        <p>{report.description}</p>
+      </section>
+
+      <section className="context-artifacts">
+        <h4>Available artifacts</h4>
+        {isLoading && <p className="muted">Loading artifacts…</p>}
+        {isError && (
+          <div className="error-callout">
+            <strong>Unable to fetch artifacts.</strong>
+            <p>Confirm the backend API is reachable.</p>
+          </div>
+        )}
+        {!isLoading && !isError && artifacts.length === 0 && (
+          <p className="muted">No artifact references were found for this report.</p>
+        )}
+        <ul>
+          {artifacts.map((artifact) => (
+            <li key={artifact.url}>
+              <span className="artifact-type">{artifact.type}</span>
+              <a href={artifact.url} target="_blank" rel="noreferrer">
+                {artifact.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/ReportSelector.css
+++ b/frontend/src/components/ReportSelector.css
@@ -1,0 +1,67 @@
+.report-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.report-tile {
+  width: 100%;
+  text-align: left;
+  padding: 1rem 1.1rem;
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  cursor: pointer;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.report-tile:hover {
+  transform: translateY(-2px);
+  border-color: rgba(79, 70, 229, 0.4);
+  box-shadow: 0 14px 35px rgba(79, 70, 229, 0.18);
+}
+
+.report-tile.active {
+  border-color: rgba(79, 70, 229, 0.9);
+  box-shadow: 0 18px 45px rgba(79, 70, 229, 0.2);
+}
+
+.report-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.report-description {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.report-artifacts {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+}
+
+.muted {
+  color: #64748b;
+  margin: 0;
+}
+
+.error-callout {
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #991b1b;
+}
+
+.error-callout p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/ReportSelector.tsx
+++ b/frontend/src/components/ReportSelector.tsx
@@ -1,0 +1,53 @@
+import type { ReportSummary } from "../types";
+import "./ReportSelector.css";
+
+interface ReportSelectorProps {
+  reports: ReportSummary[];
+  isLoading: boolean;
+  isError: boolean;
+  selectedReportId: string | null;
+  onSelect: (reportId: string) => void;
+}
+
+export function ReportSelector({
+  reports,
+  isLoading,
+  isError,
+  selectedReportId,
+  onSelect
+}: ReportSelectorProps) {
+  if (isLoading) {
+    return <p className="muted">Loading reports…</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="error-callout">
+        <strong>Unable to load reports.</strong>
+        <p>Please verify that the backend API is running.</p>
+      </div>
+    );
+  }
+
+  if (reports.length === 0) {
+    return <p className="muted">No reports are currently available.</p>;
+  }
+
+  return (
+    <ul className="report-list">
+      {reports.map((report) => (
+        <li key={report.id}>
+          <button
+            type="button"
+            className={`report-tile ${report.id === selectedReportId ? "active" : ""}`}
+            onClick={() => onSelect(report.id)}
+          >
+            <span className="report-title">{report.title}</span>
+            <span className="report-description">{report.description}</span>
+            <span className="report-artifacts">Artifacts: {report.available_artifacts.join(", ")}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/hooks/useArtifacts.ts
+++ b/frontend/src/hooks/useArtifacts.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchArtifacts } from "../api";
+
+export function useArtifacts(reportId: string | null) {
+  return useQuery({
+    queryKey: ["artifacts", reportId],
+    queryFn: () => {
+      if (!reportId) {
+        throw new Error("reportId is required");
+      }
+      return fetchArtifacts(reportId);
+    },
+    enabled: Boolean(reportId)
+  });
+}

--- a/frontend/src/hooks/useReports.ts
+++ b/frontend/src/hooks/useReports.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchReports } from "../api";
+
+export function useReports() {
+  return useQuery({
+    queryKey: ["reports"],
+    queryFn: fetchReports
+  });
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,19 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+button, input, textarea {
+  font-family: inherit;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App.tsx";
+import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 1000 * 30
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,31 @@
+export interface ReportSummary {
+  id: string;
+  title: string;
+  description: string;
+  available_artifacts: string[];
+}
+
+export interface ArtifactReference {
+  type: string;
+  label: string;
+  url: string;
+}
+
+export type ChatRole = "user" | "assistant";
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatQueryResponse {
+  answer: string;
+  citations: ArtifactReference[];
+  follow_up_questions?: string[];
+}
+
+export interface ChatConversationItem extends ChatMessage {
+  id: string;
+  citations?: ArtifactReference[];
+  follow_up_questions?: string[];
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React TypeScript frontend with shared query client configuration
- add report selector, conversational chat panel, and context panel components backed by the Django API
- centralize API helpers and React Query hooks for fetching reports, artifacts, and chat responses

## Testing
- `npm install` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04e3ffbf48321832f24400b507220