### PR TITLE
Add foundational CloudFormation templates for frontend and backend

### DIFF
--- a/infrastructure/templates/backend.yaml
+++ b/infrastructure/templates/backend.yaml
@@ -50,6 +50,27 @@ Parameters:
     Type: Number
     Default: 80
     Description: Listener port for the Application Load Balancer.
+  DomainName:
+    Type: String
+    Default: ''
+    Description: Optional custom domain for the backend CloudFront distribution.
+  AcmCertificateArn:
+    Type: String
+    Default: ''
+    Description: ACM certificate ARN in us-east-1 for the custom backend domain.
+  PriceClass:
+    Type: String
+    Default: PriceClass_100
+    AllowedValues:
+      - PriceClass_100
+      - PriceClass_200
+      - PriceClass_All
+    Description: CloudFront price class for the backend distribution.
+
+Conditions:
+  HasCustomDomain: !Not [!Equals [!Ref DomainName, '']]
+  HasCertificate: !Not [!Equals [!Ref AcmCertificateArn, '']]
+  UseCustomDomain: !And [!Condition HasCustomDomain, !Condition HasCertificate]
 
 Resources:
   BackendCluster:
@@ -237,6 +258,65 @@ Resources:
       Port: !Ref ListenerPort
       Protocol: HTTP
 
+  BackendOriginRequestPolicy:
+    Type: AWS::CloudFront::OriginRequestPolicy
+    Properties:
+      OriginRequestPolicyConfig:
+        Comment: !Sub "Forward all viewer context to ${EnvironmentName} backend origin"
+        Name: !Sub "${EnvironmentName}-backend-origin-request"
+        CookiesConfig:
+          CookieBehavior: all
+        HeadersConfig:
+          HeaderBehavior: allViewer
+        QueryStringsConfig:
+          QueryStringBehavior: all
+
+  BackendDistribution:
+    Type: AWS::CloudFront::Distribution
+    DependsOn:
+      - BackendListener
+    Properties:
+      DistributionConfig:
+        Aliases: !If
+          - UseCustomDomain
+          - [!Ref DomainName]
+          - !Ref AWS::NoValue
+        Comment: !Sub "${EnvironmentName} backend distribution"
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - PATCH
+            - POST
+            - DELETE
+          CachedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          CachePolicyId: 413bf1f5-95ef-40fb-9a61-2e41a1b0f6a0
+          Compress: true
+          OriginRequestPolicyId: !Ref BackendOriginRequestPolicy
+          TargetOriginId: !Sub "${EnvironmentName}-backend-origin"
+          ViewerProtocolPolicy: redirect-to-https
+        Enabled: true
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        Origins:
+          - Id: !Sub "${EnvironmentName}-backend-origin"
+            DomainName: !GetAtt BackendLoadBalancer.DNSName
+            CustomOriginConfig:
+              HTTPPort: !Ref ListenerPort
+              OriginProtocolPolicy: http-only
+        PriceClass: !Ref PriceClass
+        ViewerCertificate: !If
+          - UseCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            MinimumProtocolVersion: TLSv1.2_2021
+            SslSupportMethod: sni-only
+          - CloudFrontDefaultCertificate: true
+
   BackendService:
     Type: AWS::ECS::Service
     DependsOn:
@@ -276,6 +356,12 @@ Outputs:
   LoadBalancerDNSName:
     Description: DNS name of the backend Application Load Balancer.
     Value: !GetAtt BackendLoadBalancer.DNSName
+  DistributionId:
+    Description: Identifier of the CloudFront distribution serving the backend API.
+    Value: !Ref BackendDistribution
+  DistributionDomainName:
+    Description: Domain name of the CloudFront distribution serving the backend API.
+    Value: !GetAtt BackendDistribution.DomainName
   TargetGroupArn:
     Description: ARN of the backend target group.
     Value: !Ref BackendTargetGroup

--- a/infrastructure/templates/backend.yaml
+++ b/infrastructure/templates/backend.yaml
@@ -1,0 +1,284 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Backend infrastructure for the Singlecell AI Insights application using Amazon ECS
+  on AWS Fargate behind an Application Load Balancer.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Description: Short name used to identify the deployment environment (e.g. dev, prod).
+  VpcId:
+    Type: String
+    Description: Identifier of the VPC where backend resources will be created.
+  ServiceSubnets:
+    Type: CommaDelimitedList
+    Description: Subnet identifiers used by the ECS service tasks.
+  LoadBalancerSubnets:
+    Type: CommaDelimitedList
+    Description: Subnet identifiers used by the Application Load Balancer.
+  ContainerImage:
+    Type: String
+    Description: Container image URI to deploy for the backend service.
+  ContainerPort:
+    Type: Number
+    Default: 8000
+    Description: Container port exposed by the backend application.
+  DesiredCount:
+    Type: Number
+    Default: 1
+    Description: Desired number of ECS tasks running for the backend service.
+  Cpu:
+    Type: Number
+    Default: 512
+    Description: CPU units allocated to each task definition revision.
+  Memory:
+    Type: Number
+    Default: 1024
+    Description: Memory (MiB) allocated to each task definition revision.
+  HealthCheckPath:
+    Type: String
+    Default: /
+    Description: HTTP health check path for the backend load balancer target group.
+  AssignPublicIp:
+    Type: String
+    AllowedValues:
+      - ENABLED
+      - DISABLED
+    Default: ENABLED
+    Description: Whether the ECS tasks receive a public IP address.
+  ListenerPort:
+    Type: Number
+    Default: 80
+    Description: Listener port for the Application Load Balancer.
+
+Resources:
+  BackendCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${EnvironmentName}-backend"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-cluster"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Path: /
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-task-execution-role"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: !Sub "${EnvironmentName}-backend-logs"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-task-role"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/ecs/${EnvironmentName}/backend"
+      RetentionInDays: 30
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendLoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow inbound HTTP traffic to the backend load balancer.
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow internet access to the backend service.
+          FromPort: !Ref ListenerPort
+          IpProtocol: tcp
+          ToPort: !Ref ListenerPort
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic.
+          FromPort: 0
+          IpProtocol: -1
+          ToPort: 0
+      VpcId: !Ref VpcId
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-alb-sg"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow the load balancer to reach backend tasks.
+      SecurityGroupIngress:
+        - Description: Allow traffic from the load balancer.
+          FromPort: !Ref ContainerPort
+          IpProtocol: tcp
+          SourceSecurityGroupId: !Ref BackendLoadBalancerSecurityGroup
+          ToPort: !Ref ContainerPort
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic.
+          FromPort: 0
+          IpProtocol: -1
+          ToPort: 0
+      VpcId: !Ref VpcId
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-service-sg"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Cpu: !Ref Cpu
+      ExecutionRoleArn: !GetAtt BackendTaskExecutionRole.Arn
+      Family: !Sub "${EnvironmentName}-backend"
+      Memory: !Ref Memory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      RuntimePlatform:
+        CpuArchitecture: X86_64
+        OperatingSystemFamily: LINUX
+      TaskRoleArn: !GetAtt BackendTaskRole.Arn
+      ContainerDefinitions:
+        - Name: !Sub "${EnvironmentName}-backend"
+          Image: !Ref ContainerImage
+          Essential: true
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+              Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref BackendLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: backend
+
+  BackendLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${EnvironmentName}-backend"
+      Scheme: internet-facing
+      Subnets: !Ref LoadBalancerSubnets
+      SecurityGroups:
+        - !Ref BackendLoadBalancerSecurityGroup
+      Type: application
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-alb"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: !Ref HealthCheckPath
+      HealthCheckProtocol: HTTP
+      Matcher:
+        HttpCode: 200-399
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: !Ref VpcId
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-tg"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  BackendListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref BackendTargetGroup
+      LoadBalancerArn: !Ref BackendLoadBalancer
+      Port: !Ref ListenerPort
+      Protocol: HTTP
+
+  BackendService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - BackendListener
+    Properties:
+      Cluster: !Ref BackendCluster
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: !Sub "${EnvironmentName}-backend"
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref BackendTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !Ref AssignPublicIp
+          SecurityGroups:
+            - !Ref BackendServiceSecurityGroup
+          Subnets: !Ref ServiceSubnets
+      PlatformVersion: LATEST
+      TaskDefinition: !Ref BackendTaskDefinition
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-backend-service"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+Outputs:
+  ClusterName:
+    Description: Name of the ECS cluster running the backend application.
+    Value: !Ref BackendCluster
+  ServiceName:
+    Description: Name of the ECS service running the backend application.
+    Value: !GetAtt BackendService.Name
+  LoadBalancerDNSName:
+    Description: DNS name of the backend Application Load Balancer.
+    Value: !GetAtt BackendLoadBalancer.DNSName
+  TargetGroupArn:
+    Description: ARN of the backend target group.
+    Value: !Ref BackendTargetGroup
+  LogGroupName:
+    Description: CloudWatch Logs group capturing backend container logs.
+    Value: !Ref BackendLogGroup

--- a/infrastructure/templates/common/common-resources.yaml
+++ b/infrastructure/templates/common/common-resources.yaml
@@ -1,0 +1,119 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Shared networking resources that support the Singlecell AI Insights application
+  stacks.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Description: Short name used to identify the deployment environment (e.g. dev, prod).
+  VpcCidrBlock:
+    Type: String
+    Default: 10.0.0.0/16
+    Description: CIDR block assigned to the application VPC.
+  PublicSubnetACidr:
+    Type: String
+    Default: 10.0.0.0/20
+    Description: CIDR block for the first public subnet.
+  PublicSubnetBCidr:
+    Type: String
+    Default: 10.0.16.0/20
+    Description: CIDR block for the second public subnet.
+
+Resources:
+  ApplicationVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidrBlock
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-vpc"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-igw"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  VpcGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref ApplicationVpc
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref ApplicationVpc
+      AvailabilityZone: !Select [0, !GetAZs '']
+      CidrBlock: !Ref PublicSubnetACidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-public-a"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref ApplicationVpc
+      AvailabilityZone: !Select [1, !GetAZs '']
+      CidrBlock: !Ref PublicSubnetBCidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-public-b"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref ApplicationVpc
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-public-rt"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetAAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetA
+
+  PublicSubnetBAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetB
+
+Outputs:
+  VpcId:
+    Description: Identifier of the application VPC.
+    Value: !Ref ApplicationVpc
+  PublicSubnetIds:
+    Description: Comma-delimited list of public subnet identifiers.
+    Value: !Join [",", [!Ref PublicSubnetA, !Ref PublicSubnetB]]
+  PublicSubnetAId:
+    Description: Identifier of the first public subnet.
+    Value: !Ref PublicSubnetA
+  PublicSubnetBId:
+    Description: Identifier of the second public subnet.
+    Value: !Ref PublicSubnetB

--- a/infrastructure/templates/frontend.yaml
+++ b/infrastructure/templates/frontend.yaml
@@ -1,0 +1,135 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Frontend infrastructure for the Singlecell AI Insights application including S3
+  hosting and CloudFront distribution.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Description: Short name used to identify the deployment environment (e.g. dev, prod).
+  DomainName:
+    Type: String
+    Default: ''
+    Description: Optional custom domain for the CloudFront distribution.
+  AcmCertificateArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ACM certificate ARN in us-east-1 for the custom domain. Required when
+      DomainName is provided.
+  DefaultRootObject:
+    Type: String
+    Default: index.html
+    Description: Default root object served by CloudFront when no path is specified.
+  PriceClass:
+    Type: String
+    Default: PriceClass_100
+    AllowedValues:
+      - PriceClass_100
+      - PriceClass_200
+      - PriceClass_All
+    Description: CloudFront price class used for the distribution.
+
+Conditions:
+  HasCustomDomain: !Not [!Equals [!Ref DomainName, '']]
+  HasCertificate: !Not [!Equals [!Ref AcmCertificateArn, '']]
+  UseCustomDomain: !And [!Condition HasCustomDomain, !Condition HasCertificate]
+
+Resources:
+  FrontendBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${EnvironmentName}-frontend-${AWS::AccountId}-${AWS::Region}"
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      Tags:
+        - Key: Name
+          Value: !Sub "${EnvironmentName}-frontend-bucket"
+        - Key: Environment
+          Value: !Ref EnvironmentName
+
+  FrontendOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Description: !Sub "Access control for ${EnvironmentName} frontend bucket"
+        Name: !Sub "${EnvironmentName}-frontend-oac"
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  FrontendDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: !Sub "${EnvironmentName} frontend distribution"
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          Compress: true
+          TargetOriginId: !Sub "${EnvironmentName}-frontend-origin"
+          ViewerProtocolPolicy: redirect-to-https
+        DefaultRootObject: !Ref DefaultRootObject
+        Enabled: true
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        Origins:
+          - Id: !Sub "${EnvironmentName}-frontend-origin"
+            DomainName: !GetAtt FrontendBucket.RegionalDomainName
+            OriginAccessControlId: !Ref FrontendOriginAccessControl
+            S3OriginConfig: {}
+        PriceClass: !Ref PriceClass
+        Aliases: !If
+          - UseCustomDomain
+          - [!Ref DomainName]
+          - !Ref AWS::NoValue
+        ViewerCertificate: !If
+          - UseCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            MinimumProtocolVersion: TLSv1.2_2021
+            SslSupportMethod: sni-only
+          - CloudFrontDefaultCertificate: true
+
+  FrontendBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn: FrontendDistribution
+    Properties:
+      Bucket: !Ref FrontendBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowCloudFrontServicePrincipalReadOnly
+            Action: s3:GetObject
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Resource: !Sub "${FrontendBucket.Arn}/*"
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${FrontendDistribution}"
+
+Outputs:
+  BucketName:
+    Description: Name of the S3 bucket hosting the frontend build artifacts.
+    Value: !Ref FrontendBucket
+  DistributionId:
+    Description: Identifier of the CloudFront distribution.
+    Value: !Ref FrontendDistribution
+  DistributionDomainName:
+    Description: Domain name of the CloudFront distribution.
+    Value: !GetAtt FrontendDistribution.DomainName

--- a/infrastructure/templates/main.yaml
+++ b/infrastructure/templates/main.yaml
@@ -66,6 +66,24 @@ Parameters:
     Description: >-
       Optional comma-delimited list of subnet IDs for the backend load balancer. When
       empty the subnets created by the common stack are used.
+  BackendDomainName:
+    Type: String
+    Default: ''
+    Description: Optional custom domain name for the backend CloudFront distribution.
+  BackendAcmCertificateArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ACM certificate ARN in us-east-1 for the custom backend domain. Required when
+      BackendDomainName is provided.
+  BackendPriceClass:
+    Type: String
+    Default: PriceClass_100
+    AllowedValues:
+      - PriceClass_100
+      - PriceClass_200
+      - PriceClass_All
+    Description: CloudFront price class used for the backend distribution.
 
 Conditions:
   HasBackendServiceSubnetOverride: !Not [!Equals [!Ref BackendServiceSubnetsOverride, '']]
@@ -118,6 +136,9 @@ Resources:
         Memory: !Ref BackendMemory
         HealthCheckPath: !Ref BackendHealthCheckPath
         AssignPublicIp: !Ref BackendAssignPublicIp
+        DomainName: !Ref BackendDomainName
+        AcmCertificateArn: !Ref BackendAcmCertificateArn
+        PriceClass: !Ref BackendPriceClass
     DependsOn:
       - CommonStack
 
@@ -131,6 +152,12 @@ Outputs:
   BackendServiceName:
     Description: Name of the ECS service running the backend application.
     Value: !GetAtt [BackendStack, Outputs.ServiceName]
+  BackendDistributionDomainName:
+    Description: CloudFront distribution domain name for the backend API.
+    Value: !GetAtt [BackendStack, Outputs.DistributionDomainName]
+  BackendDistributionId:
+    Description: Identifier of the CloudFront distribution serving the backend API.
+    Value: !GetAtt [BackendStack, Outputs.DistributionId]
   BackendLoadBalancerDNSName:
     Description: Public DNS name for the backend application load balancer.
     Value: !GetAtt [BackendStack, Outputs.LoadBalancerDNSName]

--- a/infrastructure/templates/main.yaml
+++ b/infrastructure/templates/main.yaml
@@ -1,0 +1,139 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Primary CloudFormation template that orchestrates the Singlecell AI Insights
+  application by delegating resource provisioning to nested stacks.
+
+Parameters:
+  EnvironmentName:
+    Type: String
+    Description: Short name used to identify the deployment environment (e.g. dev, prod).
+  TemplateBucketName:
+    Type: String
+    Description: Name of the S3 bucket that stores the nested CloudFormation templates.
+  TemplatePrefix:
+    Type: String
+    Default: infrastructure/templates
+    Description: Prefix within the template bucket where nested templates are stored.
+  FrontendDomainName:
+    Type: String
+    Default: ''
+    Description: Optional custom domain name for the frontend distribution.
+  FrontendAcmCertificateArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ACM certificate ARN in us-east-1 for the custom frontend domain. Required when
+      FrontendDomainName is provided.
+  BackendContainerImage:
+    Type: String
+    Description: Container image URI to deploy for the backend service.
+  BackendContainerPort:
+    Type: Number
+    Default: 8000
+    Description: Container port exposed by the backend application.
+  BackendDesiredCount:
+    Type: Number
+    Default: 1
+    Description: Desired number of ECS tasks for the backend service.
+  BackendCpu:
+    Type: Number
+    Default: 512
+    Description: CPU units allocated to each backend task definition (e.g. 256, 512, 1024).
+  BackendMemory:
+    Type: Number
+    Default: 1024
+    Description: Memory (MiB) allocated to each backend task definition.
+  BackendHealthCheckPath:
+    Type: String
+    Default: /
+    Description: HTTP path used by the load balancer to health check the backend service.
+  BackendAssignPublicIp:
+    Type: String
+    AllowedValues:
+      - ENABLED
+      - DISABLED
+    Default: ENABLED
+    Description: Whether backend tasks receive a public IP address.
+  BackendServiceSubnetsOverride:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional comma-delimited list of subnet IDs for backend tasks. When empty the
+      subnets created by the common stack are used.
+  BackendLoadBalancerSubnetsOverride:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional comma-delimited list of subnet IDs for the backend load balancer. When
+      empty the subnets created by the common stack are used.
+
+Conditions:
+  HasBackendServiceSubnetOverride: !Not [!Equals [!Ref BackendServiceSubnetsOverride, '']]
+  HasBackendLoadBalancerSubnetOverride: !Not [!Equals [!Ref BackendLoadBalancerSubnetsOverride, '']]
+
+Resources:
+  CommonStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${TemplateBucketName}.s3.${AWS::Region}.amazonaws.com/${TemplatePrefix}/${CommonTemplatePath}
+        - { CommonTemplatePath: common/common-resources.yaml }
+      Parameters:
+        EnvironmentName: !Ref EnvironmentName
+
+  FrontendStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${TemplateBucketName}.s3.${AWS::Region}.amazonaws.com/${TemplatePrefix}/${FrontendTemplatePath}
+        - { FrontendTemplatePath: frontend.yaml }
+      Parameters:
+        EnvironmentName: !Ref EnvironmentName
+        DomainName: !Ref FrontendDomainName
+        AcmCertificateArn: !Ref FrontendAcmCertificateArn
+    DependsOn:
+      - CommonStack
+
+  BackendStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${TemplateBucketName}.s3.${AWS::Region}.amazonaws.com/${TemplatePrefix}/${BackendTemplatePath}
+        - { BackendTemplatePath: backend.yaml }
+      Parameters:
+        EnvironmentName: !Ref EnvironmentName
+        VpcId: !GetAtt [CommonStack, Outputs.VpcId]
+        ServiceSubnets: !If
+          - HasBackendServiceSubnetOverride
+          - !Ref BackendServiceSubnetsOverride
+          - !GetAtt [CommonStack, Outputs.PublicSubnetIds]
+        LoadBalancerSubnets: !If
+          - HasBackendLoadBalancerSubnetOverride
+          - !Ref BackendLoadBalancerSubnetsOverride
+          - !GetAtt [CommonStack, Outputs.PublicSubnetIds]
+        ContainerImage: !Ref BackendContainerImage
+        ContainerPort: !Ref BackendContainerPort
+        DesiredCount: !Ref BackendDesiredCount
+        Cpu: !Ref BackendCpu
+        Memory: !Ref BackendMemory
+        HealthCheckPath: !Ref BackendHealthCheckPath
+        AssignPublicIp: !Ref BackendAssignPublicIp
+    DependsOn:
+      - CommonStack
+
+Outputs:
+  FrontendBucketName:
+    Description: Name of the S3 bucket hosting the frontend build artifacts.
+    Value: !GetAtt [FrontendStack, Outputs.BucketName]
+  FrontendDistributionDomainName:
+    Description: CloudFront distribution domain name for the frontend application.
+    Value: !GetAtt [FrontendStack, Outputs.DistributionDomainName]
+  BackendServiceName:
+    Description: Name of the ECS service running the backend application.
+    Value: !GetAtt [BackendStack, Outputs.ServiceName]
+  BackendLoadBalancerDNSName:
+    Description: Public DNS name for the backend application load balancer.
+    Value: !GetAtt [BackendStack, Outputs.LoadBalancerDNSName]
+  VpcId:
+    Description: Identifier of the VPC created for the application.
+    Value: !GetAtt [CommonStack, Outputs.VpcId]


### PR DESCRIPTION
## Summary
- add an orchestration template that wires together common, frontend, and backend nested stacks
- introduce a shared networking stack template to provision the application VPC and public subnets
- define frontend and backend templates for S3/CloudFront hosting and an ECS Fargate service behind an ALB

## Testing
- not run (infrastructure templates only)


------
https://chatgpt.com/codex/tasks/task_e_68d0ffe7a2988321bef22f2feccf0024